### PR TITLE
FIX: rightContainer 이벤트 차단

### DIFF
--- a/frontend/src/styles/componentStyles/HomeRightContainer.module.scss
+++ b/frontend/src/styles/componentStyles/HomeRightContainer.module.scss
@@ -9,7 +9,7 @@
   padding: 0 30px;
   float: left;
   z-index: 1;
-  transform: translateX(-100%);
+  transform: translateX(-70%);
   opacity: 0;
   transition: all 0.5s ease-in-out;
 
@@ -24,7 +24,7 @@
   }
 
   &.exiting {
-    transform: translateX(-100%);
+    transform: translateX(-70%);
     opacity: 0;
   }
 


### PR DESCRIPTION
- rightContainer가 사라질 때 왼쪽으로 이동하는데, 이 때 leftContainer에 겹치도록 하여 이벤트가 발생하지 않게 함

close #4