### PR TITLE
FEAT: 실전면접 페이지 이동 구현

### DIFF
--- a/backend/routes/interview.ts
+++ b/backend/routes/interview.ts
@@ -3,16 +3,15 @@ const initPrompt = require("../utils/initPrompt");
 
 router.post("/", async function (req: any, res: any) {
   const openai = req.openai;
-  let { messages } = req.body;
+  let { name, job, messages } = req.body;
 
-  let prompt = [...initPrompt, ...messages]; // 초기프롬프트와 대화내역을 프롬프트에 넣어줌
-
+  let prompt = [...initPrompt(name, job), ...messages]; // 초기프롬프트와 대화내역을 프롬프트에 넣어줌
   try {
     // GPT 호출
     const completion = await openai.createChatCompletion({
       model: "gpt-3.5-turbo",
       temperature: 0.5,
-      max_tokens: 500, // max token : 4097
+      max_tokens: 4000, // max token : 4097
       messages: prompt,
     });
 

--- a/backend/utils/initPrompt.js
+++ b/backend/utils/initPrompt.js
@@ -1,7 +1,4 @@
-let job = "직무";
-let name = "이름";
-
-const initPrompt = [
+const initPrompt = (name, job) => [
   {
     role: `system`,
     content: `

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,27 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import React, { createContext, useState } from "react";
 import "./App.scss";
 import Actual from "./pages/Actual";
 import Home from "./pages/Home";
+import { NameJobContext } from "./types/types";
+
+export const nameJobContext = createContext<NameJobContext | undefined>(
+  undefined
+);
 
 function App() {
+  const [name, setName] = useState<string>("");
+  const [job, setJob] = useState<string>("");
+
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/actual" element={<Actual />} />
-      </Routes>
-    </BrowserRouter>
+    <nameJobContext.Provider value={{ name, setName, job, setJob }}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/actual" element={<Actual />} />
+        </Routes>
+      </BrowserRouter>
+    </nameJobContext.Provider>
   );
 }
 

--- a/frontend/src/components/Home/HomeRightContainer.tsx
+++ b/frontend/src/components/Home/HomeRightContainer.tsx
@@ -1,12 +1,33 @@
 import styles from "../../styles/componentStyles/HomeRightContainer.module.scss";
-import { FC } from "react";
+import { FC, useState } from "react";
 import { HomeRightContainerProps } from "../../types/types";
 import { Transition } from "react-transition-group";
+import { useNavigate } from "react-router-dom";
 
 const HomeRightContainer: FC<HomeRightContainerProps> = ({
   selectedMode,
   rightContainerRef,
 }) => {
+  const [name, setName] = useState<string>("");
+  const [job, setJob] = useState<string>("");
+  const navigator = useNavigate();
+
+  const handleInterviewStart = () => {
+    switch (selectedMode) {
+      case 0:
+        break;
+      case 1:
+        navigator("/actual");
+        break;
+      case 2:
+        break;
+      case 3:
+        break;
+      default:
+        break;
+    }
+  };
+
   return (
     <Transition in={selectedMode !== -1} timeout={500}>
       {(state: any) => (
@@ -18,10 +39,24 @@ const HomeRightContainer: FC<HomeRightContainerProps> = ({
 
           <div className={styles.input_user_info_box}>
             <h4>이름</h4>
-            <input type="text" placeholder="이름을 입력하세요" />
+            <input
+              type="text"
+              placeholder="이름을 입력하세요"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+              }}
+            />
             <h4>직무</h4>
-            <input type="text" placeholder="직무를 입력하세요" />
-            <button>면접 시작</button>
+            <input
+              type="text"
+              placeholder="직무를 입력하세요"
+              value={job}
+              onChange={(e) => {
+                setJob(e.target.value);
+              }}
+            />
+            <button onClick={handleInterviewStart}>면접 시작</button>
           </div>
         </div>
       )}

--- a/frontend/src/components/Home/HomeRightContainer.tsx
+++ b/frontend/src/components/Home/HomeRightContainer.tsx
@@ -1,15 +1,25 @@
 import styles from "../../styles/componentStyles/HomeRightContainer.module.scss";
-import { FC, useState } from "react";
+import { FC, useContext, useEffect, useState } from "react";
 import { HomeRightContainerProps } from "../../types/types";
 import { Transition } from "react-transition-group";
 import { useNavigate } from "react-router-dom";
+import { nameJobContext } from "../../App";
+import { NameJobContext } from "../../types/types";
 
 const HomeRightContainer: FC<HomeRightContainerProps> = ({
   selectedMode,
   rightContainerRef,
 }) => {
-  const [name, setName] = useState<string>("");
-  const [job, setJob] = useState<string>("");
+  const { name, setName, job, setJob } = useContext(
+    nameJobContext
+  ) as NameJobContext;
+
+  // 마운트 시 이름과 직업 공백으로 초기화
+  useEffect(() => {
+    setName("");
+    setJob("");
+  }, []);
+
   const navigator = useNavigate();
 
   const handleInterviewStart = () => {
@@ -54,6 +64,9 @@ const HomeRightContainer: FC<HomeRightContainerProps> = ({
               value={job}
               onChange={(e) => {
                 setJob(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key == "Enter") handleInterviewStart();
               }}
             />
             <button onClick={handleInterviewStart}>면접 시작</button>

--- a/frontend/src/pages/Actual.tsx
+++ b/frontend/src/pages/Actual.tsx
@@ -7,9 +7,7 @@ import { nameJobContext } from "../App";
 import { NameJobContext } from "../types/types";
 
 const Actual: FC = () => {
-  const { name, setName, job, setJob } = useContext(
-    nameJobContext
-  ) as NameJobContext;
+  const { name, job } = useContext(nameJobContext) as NameJobContext;
   const [messages, setMessages] = useState<{ content: String; role: String }[]>(
     []
   ); // 대화 내역
@@ -46,6 +44,8 @@ const Actual: FC = () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
+        name: name,
+        job: job,
         messages: updatedMessages,
       }),
     });

--- a/frontend/src/pages/Actual.tsx
+++ b/frontend/src/pages/Actual.tsx
@@ -1,10 +1,15 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useContext } from "react";
 import ChatBox from "../components/ChatBox";
 import InputAns from "../components/InputAns";
 import styles from "../styles/pageStyles/Actual.module.scss";
 import { FC } from "react";
+import { nameJobContext } from "../App";
+import { NameJobContext } from "../types/types";
 
 const Actual: FC = () => {
+  const { name, setName, job, setJob } = useContext(
+    nameJobContext
+  ) as NameJobContext;
   const [messages, setMessages] = useState<{ content: String; role: String }[]>(
     []
   ); // 대화 내역

--- a/frontend/src/styles/componentStyles/HomeRightContainer.module.scss
+++ b/frontend/src/styles/componentStyles/HomeRightContainer.module.scss
@@ -11,7 +11,7 @@
   z-index: 1;
   transform: translateX(-70%);
   opacity: 0;
-  transition: all 0.5s ease-in-out;
+  transition: all 0.4s ease-in-out;
 
   &.entering {
     transform: translateX(0%);

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -32,3 +32,10 @@ export interface ModeBoxProps {
   selectedMode: Number;
   setSelectedMode: React.Dispatch<React.SetStateAction<Number>>;
 }
+
+export interface NameJobContext {
+  name: string;
+  setName: React.Dispatch<React.SetStateAction<string>>;
+  job: string;
+  setJob: React.Dispatch<React.SetStateAction<string>>;
+}


### PR DESCRIPTION
## 🐾 구현한 것
- 실전면접모드 누르고 면접 시작 시 실전면접 페이지로 이동하도록 구현하였습니다.
- 홈 화면에서 name, job을 입력하면 면접페이지로 넘어가고 프롬프트에 넣어서 백엔드에 넘겨주도록 구현하였습니다.
- name과 job을 넘겨줄 때 pros drilling이 생겨서 ContextAPI를 사용하여 해결하였습니다.

close #6 